### PR TITLE
allow to load images hosted on github pages

### DIFF
--- a/env_vars/base.yml
+++ b/env_vars/base.yml
@@ -97,6 +97,6 @@ content_security_policy:
   - "default-src 'self'"
   - "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://traffic.okfn.de"
   - "style-src 'self' 'unsafe-inline'"
-  - "img-src 'self' data: blob: https://traffic.okfn.de https://www.betterplace.org https://asset0.betterplace.org https://raw.githubusercontent.com"
+  - "img-src 'self' data: blob: https://traffic.okfn.de https://www.betterplace.org https://asset0.betterplace.org https://raw.githubusercontent.com https://*.github.io"
   - "worker-src 'self'"
   - "frame-src 'self' https://www.betterplace.org https://player.vimeo.com https://media.ccc.de"


### PR DESCRIPTION
The last changes required to fix https://github.com/okfde/fragdenstaat_de/issues/106. @arnese was loading pictures from e.g. https://arnese.github.io/fds-mockups/img/kampagne.png.