### PR TITLE
fix apple-app-site-association mimetype

### DIFF
--- a/env_vars/base.yml
+++ b/env_vars/base.yml
@@ -106,7 +106,7 @@ simple_files:
     content: "User-agent: *\\nDisallow:\\n"
   - path: "/.well-known/apple-app-site-association"
     content: '{"applinks":{"apps":[],"details":[{"appID":"93C29USLP6.de.okfn.fragdenstaat","paths":["/a/*","/anfrage/*"]}]}}'
-    mimetype: 'application/json'
+    mimetype: 'application/pkcs7-mime'
 
 django_sentry_dsn: ""
 content_security_policy:


### PR DESCRIPTION
The universal linking is currently not working. It looks like that I gave you the wrong content type. According to [this gist](https://gist.github.com/anhar/6d50c023f442fb2437e1#-modifying-the-content-type-of-the-apple-app-site-association-file), it has to be "application/pkcs7-mime". So let's see if this works now. 

Apple has an tool to validate the file: <https://search.developer.apple.com/appsearch-validation-tool>.

I also found <https://limitless-sierra-4673.herokuapp.com> to debug the case.