### PR TITLE
Set db_user permissions again after migration

### DIFF
--- a/roles/app/tasks/run_django_tasks.yml
+++ b/roles/app/tasks/run_django_tasks.yml
@@ -32,7 +32,7 @@
     - deploy-web
     - deploy-backend
 
-- name: "Reassign all object in database bar owned by db_user to django_migrations"
+- name: "Reassign all object in database owned by db_user to django_migrations"
   community.postgresql.postgresql_owner:
     db: "{{ db_name }}"
     new_owner: django_migrations
@@ -57,6 +57,50 @@
     - deploy-backend
   become: true
   become_user: "{{ gunicorn_user }}"
+
+- name: "Set db_user privs"
+  community.postgresql.postgresql_privs:
+    db: "{{ db_name }}"
+    role: "{{ db_user }}"
+    objs: ALL_IN_SCHEMA
+    privs: ALL
+    grant_option: true
+  become: true
+  become_user: postgres
+  tags:
+    - django.migrate
+    - deploy-web
+    - deploy-backend
+
+- name: "Set db_user schema privs"
+  community.postgresql.postgresql_privs:
+    db: "{{ db_name }}"
+    role: "{{ db_user }}"
+    objs: public
+    privs: ALL
+    grant_option: true
+    type: schema
+  become: true
+  become_user: postgres
+  tags:
+    - django.migrate
+    - deploy-web
+    - deploy-backend
+
+- name: "Set db_user sequence privs"
+  community.postgresql.postgresql_privs:
+    db: "{{ db_name }}"
+    role: "{{ db_user }}"
+    objs: ALL_IN_SCHEMA
+    privs: USAGE
+    grant_option: true
+    type: sequence
+  become: true
+  become_user: postgres
+  tags:
+    - django.migrate
+    - deploy-web
+    - deploy-backend
 
 - name: Run Django compilemessages
   ansible.builtin.command: "{{ virtualenv_path }}/bin/python {{ virtualenv_path }}/fragdenstaat.de/manage.py compilemessages -l de --ignore **node_modules/**"


### PR DESCRIPTION
If the migrations create a new table, the db_user has no permissions. This is a simply quick-fix that simply sets the permissions on every migrations. There probably is a better solution than this rather brute-force approach, feel free to implement that instead