### PR TITLE
🐛 Fix linting error for undefined item.item in nginx HTTPS domain list

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Set fact for active HTTPS domain list
   ansible.builtin.set_fact:
-    active_https_domain_list: "{{ active_https_domain_list | default([]) + item.item }}"
+    active_https_domain_list: "{{ active_https_domain_list | default([]) + (item.item | default([])) }}"
   when: item.stat.exists
   with_items: "{{ https_cert_check.results }}"
   tags:


### PR DESCRIPTION
**Problem**: GitHub Actions linting was failing with error `can only concatenate list (not "UndefinedMarker") to list` in `roles/nginx/tasks/main.yml:16`.

**Root cause**: The task was trying to concatenate `item.item` (which could be undefined) with a list when building the active HTTPS domain list.

**Solution**: Added `| default([])` filter to `item.item` to ensure it's always a list, even when undefined.
