### PR TITLE
Add smtp relay config

### DIFF
--- a/group_vars/all/default.yml
+++ b/group_vars/all/default.yml
@@ -215,6 +215,12 @@ unsubscribe_email_host: "mail.fragdenstaat.de"
 #     to: "root@fragdenstaat.de"
 
 ## in secret.yml
+smtp_relays: []
+#  - domain: ""
+#    username: ""
+#    password: ""
+
+## in secret.yml
 alias_foi_domains: []
 
 ## in secret.yml

--- a/roles/postfix/files/transport
+++ b/roles/postfix/files/transport
@@ -1,0 +1,4 @@
+stefan.wehrmeyer@okfn.de           relay:[in-v3.mailjet.com]:587
+fragdenstaat.de                    local
+echtemail.de                       local
+*                                  smtp

--- a/roles/postfix/handlers/main.yml
+++ b/roles/postfix/handlers/main.yml
@@ -16,6 +16,18 @@
   notify: restart postfix
   changed_when: false
 
+- name: update transport postmap
+  ansible.builtin.command:
+    cmd: "postmap /etc/postfix/transport"
+  notify: restart postfix
+  changed_when: false
+
+- name: update sasl_passwd postmap
+  ansible.builtin.command:
+    cmd: "postmap /etc/postfix/sasl_passwd"
+  notify: restart postfix
+  changed_when: false
+
 - name: restart opendkim
   ansible.builtin.service:
     name: opendkim

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Ensure postfix and dependencies are installed
   ansible.builtin.apt:
     pkg:
@@ -36,6 +35,20 @@
     dest: /etc/postfix/master.cf
     mode: "0644"
   notify: restart postfix
+
+- name: Install transport
+  ansible.builtin.copy:
+    src: transport
+    dest: /etc/postfix/transport
+    mode: "0600"
+  notify: update transport postmap
+
+- name: Install postfix sasl_passwd
+  ansible.builtin.template:
+    src: sasl_passwd.j2
+    dest: /etc/postfix/sasl_passwd
+    mode: "0600"
+  notify: update sasl_passwd postmap
 
 - name: Install vmail_domains
   ansible.builtin.template:

--- a/roles/postfix/templates/main.cf.j2
+++ b/roles/postfix/templates/main.cf.j2
@@ -158,3 +158,11 @@ smtpd_milters =
     inet:127.0.0.1:12301
     inet:127.0.0.1:8893
 non_smtpd_milters = inet:localhost:12301
+
+transport_maps = hash:/etc/postfix/transport
+
+smtp_sasl_auth_enable = yes
+smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
+smtp_sasl_security_options = noanonymous
+smtp_tls_security_level = may
+header_size_limit = 4096000

--- a/roles/postfix/templates/sasl_passwd.j2
+++ b/roles/postfix/templates/sasl_passwd.j2
@@ -1,0 +1,2 @@
+{% for smtp in smtp_relays %}[{{ smtp.domain }}]:587                     {{ smtp.username }}:{{ smtp.password }}
+{% endfor %}


### PR DESCRIPTION
In order to sent mail for certain recipient domains via relay. For testing my own email address is in there for now. Relay has not been configured in secret yet.