### PR TITLE
🐛 Fix FOI mail delivery broken by no_address_mappings

### DIFF
--- a/roles/postfix/handlers/main.yml
+++ b/roles/postfix/handlers/main.yml
@@ -38,6 +38,12 @@
     name: opendmarc
     state: restarted
 
+- name: update spamfilter_access postmap
+  ansible.builtin.command:
+    cmd: "postmap /etc/postfix/spamfilter_access"
+  notify: restart postfix
+  changed_when: false
+
 - name: restart spamassassin
   ansible.builtin.service:
     name: spamassassin

--- a/roles/postfix/tasks/spamassassin.yml
+++ b/roles/postfix/tasks/spamassassin.yml
@@ -17,7 +17,7 @@
   notify:
     - restart spamassassin
 
-- name: Configure postfix
+- name: Configure postfix master.cf for spamassassin
   ansible.builtin.blockinfile:
     path: /etc/postfix/master.cf
     append_newline: true
@@ -25,6 +25,13 @@
     block: |
       spamassassin unix -     n       n       -       -       pipe
         user=spamd argv=/usr/bin/spamc -f -e /usr/sbin/sendmail -oi -f ${sender} ${recipient}
+
+- name: Install spamfilter_access map
+  ansible.builtin.template:
+    src: spamfilter_access.j2
+    dest: /etc/postfix/spamfilter_access
+    mode: "0644"
+  notify: update spamfilter_access postmap
 
 - name: Install cronjob to keep data up to date
   ansible.builtin.cron:

--- a/roles/postfix/templates/main.cf.j2
+++ b/roles/postfix/templates/main.cf.j2
@@ -79,6 +79,7 @@ smtpd_relay_restrictions =
 
 smtpd_recipient_restrictions =
     check_recipient_access pcre:/etc/postfix/blocklisted_recipients,
+    check_recipient_access hash:/etc/postfix/spamfilter_access,
     permit_mynetworks,
     permit_sasl_authenticated,
     reject_unauth_destination,

--- a/roles/postfix/templates/master.cf.j2
+++ b/roles/postfix/templates/master.cf.j2
@@ -9,7 +9,6 @@
 #               (yes)   (yes)   (yes)   (never) (100)
 # ==========================================================================
 smtp      inet  n       -       y       -       -       smtpd
-  -o receive_override_options=no_address_mappings
 submission inet n       -       y       -       -       smtpd
   -o smtpd_tls_security_level=encrypt
   -o smtpd_sasl_auth_enable=yes

--- a/roles/postfix/templates/spamfilter_access.j2
+++ b/roles/postfix/templates/spamfilter_access.j2
@@ -1,0 +1,1 @@
+info@{{ domain_name }}  FILTER spamassassin:

--- a/roles/postfix/templates/transport.j2
+++ b/roles/postfix/templates/transport.j2
@@ -1,5 +1,4 @@
 {% for transport in transport_maps %}{{ transport.from }}       relay:[{{ transport.to }}]:587
-{% endfor %}info@fragdenstaat.de    spamassassin:
-fragdenstaat.de        dovecot
+{% endfor %}fragdenstaat.de        dovecot
 echtemail.de                       dovecot
 *                                  smtp


### PR DESCRIPTION
- Remove receive_override_options=no_address_mappings from smtp service
- Remove info@ spamassassin transport entry from transport map
- Add per-recipient FILTER via check_recipient_access for info@ spam filtering
- Add spamfilter_access template, deploy task and postmap handler