### PR TITLE
Improve migration error handling

### DIFF
--- a/roles/app/tasks/migrate_db.yml
+++ b/roles/app/tasks/migrate_db.yml
@@ -81,7 +81,6 @@
     - restart celery workers
     - set db access rights
   changed_when: true
-  ignore_errors: true
   when: not ansible_check_mode
 
 - name: Setup reporting views

--- a/roles/app/tasks/run_django_tasks.yml
+++ b/roles/app/tasks/run_django_tasks.yml
@@ -22,7 +22,7 @@
 
 - name: Set needs db migration fact
   ansible.builtin.set_fact:
-    needs_db_migration: "{{ 'No planned migration operations.' not in migrate_check_result.out }}"
+    needs_db_migration: "{{ 'No planned migration operations.' not in migrate_check_result.out | default('') }}"
   tags:
     - deploy
     - deploy-backend


### PR DESCRIPTION
Stop silently ignoring migration errors by removing `ignore_errors: true` from the migrate task. Add a `default('')` fallback to the migration plan check so it doesn't fail when the output is empty. Currently, a failure there shadows the real migration error, making debugging harder.