### PR TITLE
Restrict postfix config

### DIFF
--- a/roles/auxsmtp/templates/main.cf.j2
+++ b/roles/auxsmtp/templates/main.cf.j2
@@ -71,6 +71,16 @@ smtp_tls_security_level = dane
 smtpd_use_tls=no
 {% endif %}
 
+smtpd_helo_restrictions =
+    permit_mynetworks,
+    check_helo_access pcre:/etc/postfix/reject_helo,
+    permit
+
+smtpd_sender_restrictions =
+    permit_sasl_authenticated,
+    reject_unknown_sender_domain,
+    check_sender_access pcre:/etc/postfix/reject_domains
+
 smtpd_relay_restrictions =
     permit_mynetworks
     permit_sasl_authenticated
@@ -81,11 +91,6 @@ smtpd_recipient_restrictions =
     permit_mynetworks,
     permit_sasl_authenticated,
     reject_unauth_destination,
-
-smtpd_helo_restrictions =
-    permit_mynetworks,
-    check_helo_access pcre:/etc/postfix/reject_helo,
-    permit
 
 mydomain = {{ domain_name }}
 myhostname = {{ postfix_hostname }}
@@ -118,7 +123,6 @@ virtual_mailbox_base = /var/vmail
 
 # receive_override_options=no_address_mappings
 smtpd_sasl_local_domain = $myhostname
-smtpd_sender_restrictions = permit_sasl_authenticated, reject_unknown_sender_domain, check_sender_access pcre:/etc/postfix/reject_domains
 
 smtp_use_tls = yes
 tls_random_source = dev:/dev/urandom

--- a/roles/postfix/templates/main.cf.j2
+++ b/roles/postfix/templates/main.cf.j2
@@ -72,6 +72,19 @@ smtpd_tls_received_header = yes
 smtpd_use_tls=no
 {% endif %}
 
+# smtpd restrictions
+
+smtpd_helo_restrictions =
+    permit_mynetworks,
+    check_helo_access pcre:/etc/postfix/reject_helo,
+    permit
+
+smtpd_sender_restrictions =
+    permit_sasl_authenticated,
+    permit_mynetworks,
+    reject_unknown_sender_domain,
+    check_sender_access pcre:/etc/postfix/reject_domains
+
 smtpd_relay_restrictions =
     permit_mynetworks
     permit_sasl_authenticated
@@ -84,11 +97,6 @@ smtpd_recipient_restrictions =
     permit_sasl_authenticated,
     reject_unauth_destination,
     check_policy_service unix:private/policy-spf
-
-smtpd_helo_restrictions =
-    permit_mynetworks,
-    check_helo_access pcre:/etc/postfix/reject_helo,
-    permit
 
 # mitigation for https://www.postfix.org/smtp-smuggling.html
 smtpd_data_restrictions = reject_unauth_pipelining
@@ -143,12 +151,10 @@ smtpd_sasl_path = private/auth
 
 # receive_override_options=no_address_mappings
 smtpd_sasl_local_domain = $myhostname
-smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain, check_sender_access pcre:/etc/postfix/reject_domains
 # mailbox_command = /usr/lib/dovecot/deliver -c /etc/dovecot/conf.d/01-mail-stack-delivery.conf -m "${EXTENSION}"
 
 smtp_use_tls = yes
 tls_random_source = dev:/dev/urandom
-
 
 # SPF https://help.ubuntu.com/community/Postfix/SPF
 policy-spf_time_limit = 3600s

--- a/roles/postfix/templates/main.cf.j2
+++ b/roles/postfix/templates/main.cf.j2
@@ -80,8 +80,11 @@ smtpd_helo_restrictions =
     permit
 
 smtpd_sender_restrictions =
-    permit_sasl_authenticated,
     permit_mynetworks,
+    # alias for "reject_authenticated_sender_login_mismatch, reject_unauthenticated_sender_login_mismatch"
+    # Check *before* allowing all authenticated mail
+    reject_sender_login_mismatch,
+    permit_sasl_authenticated,
     reject_unknown_sender_domain,
     check_sender_access pcre:/etc/postfix/reject_domains
 
@@ -92,11 +95,12 @@ smtpd_relay_restrictions =
 
 smtpd_recipient_restrictions =
     check_recipient_access pcre:/etc/postfix/blocklisted_recipients,
-    check_recipient_access hash:/etc/postfix/spamfilter_access,
+    # TODO: Some are superflous since we set this in smtpd_relay_restrictions, see https://www.postfix.org/SMTPD_ACCESS_README.html
     permit_mynetworks,
     permit_sasl_authenticated,
     reject_unauth_destination,
     check_policy_service unix:private/policy-spf
+    check_recipient_access hash:/etc/postfix/spamfilter_access,
 
 # mitigation for https://www.postfix.org/smtp-smuggling.html
 smtpd_data_restrictions = reject_unauth_pipelining


### PR DESCRIPTION
This PR comprises mostly of two changes in the postfix role and some tidying up:

`smtpd_sender_restrictions`: 
Add `reject_sender_login_mismatch` before `permit_sasl_authenticated` and move `permit_sasl_authenticated` down in order: Currently allow any authenicated user to send mail, but we do not check if the authenticated user is authorized to use the envelope address specified in MAIL FROM, which might allow logged in users to spoof existing user accounts

`smtpd_recipient_restrictions`:
Move `check_recipient_access hash:/etc/postfix/spamfilter_access` to the bottom of the list: Placing it at the top effectively renders all the latter directives like `reject_unauth_destination` useless if spamassassin approves a mail

The rest ist reordering of both auxsmtp and postfix role for better readability. Also I have added a TODO because I think that some config might be superflous, but that can be done in another PR.