### PR TITLE
Add List-Unsubscribe-Post to signed headers

### DIFF
--- a/roles/postfix/templates/opendkim/opendkim.conf.j2
+++ b/roles/postfix/templates/opendkim/opendkim.conf.j2
@@ -21,3 +21,5 @@ SignatureAlgorithm      rsa-sha256
 UserID                  opendkim:opendkim
 
 Socket                  inet:12301@localhost
+SignHeaders             From,Sender,To,CC,Subject,Message-Id,Date,MIME-Version,Content-Type,Reply-To,List-Unsubscribe,List-Unsubscribe-Post
+OversignHeaders         From,Sender,To,CC,Subject,Message-Id,Date,MIME-Version,Content-Type,Reply-To,List-Unsubscribe,List-Unsubscribe-Post


### PR DESCRIPTION
Also add OversignHeaders config.

In order to comply with RFC 8058 all List-Unsubscribe* headers must be covered by DKIM signing.