### PR TITLE
Git hook: Fix grep regex

### DIFF
--- a/git_hooks/check_vault.sh
+++ b/git_hooks/check_vault.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-FILES='secrets\.yml|vpnclients\.yml|*\.vault|*\.vault.yml'
+FILES='secret(s?)\.y(a?)ml|vpnclients\.y(a?)ml|\.vault|\.vault.y(a?)ml'
 
 for f in $(git diff --cached --name-only | grep -E ${FILES}); do
-    if [ ! $(git show :${f} | head -n 1 | grep 'ANSIBLE_VAULT') ]; then
+    if ! git show :${f} | head -n 1 | grep 'ANSIBLE_VAULT'; then
 	echo "${f} is an unencrypted vault file, rejecting..."
 	echo "Please encrypt via 'ansible-vault' and try again."
 	exit 1


### PR DESCRIPTION
The `*` does not make sense and throws an error for me:
```
grep: Warnung: »*« am Anfang des Ausdrucks
grep: Warnung: »*« am Anfang des Ausdrucks
```

Maybe we can drop the `.vault` and `.vault.yml` extentension altogether, we don't use it anyway.

Also match against typo `secret.yml` without s